### PR TITLE
Move Parameterhandling into Runner

### DIFF
--- a/src/LijsDev.CrystalReportsRunner.Core/Report.cs
+++ b/src/LijsDev.CrystalReportsRunner.Core/Report.cs
@@ -1,8 +1,7 @@
 namespace LijsDev.CrystalReportsRunner.Core;
 
-using Newtonsoft.Json;
-using System.Collections.Generic;
 using System.Data;
+using Newtonsoft.Json;
 
 /// <summary>
 /// Report
@@ -59,6 +58,11 @@ public sealed class Report
 
     /// <inheritdoc/>
     public Dictionary<string, object> Parameters { get; set; } = [];
+
+    /// <summary>
+    /// String that can be used to extend the RecordSelectionFormula with an additional Filter
+    /// </summary>
+    public string WhereStatement { get; set; } = string.Empty;
 
     /// <inheritdoc/>
     public List<DataSet> DataSets { get; set; } = [];

--- a/src/LijsDev.CrystalReportsRunner.Core/Report.cs
+++ b/src/LijsDev.CrystalReportsRunner.Core/Report.cs
@@ -9,13 +9,20 @@ using Newtonsoft.Json;
 [Serializable]
 public sealed class Report
 {
-    /// <inheritdoc/>
+    /// <summary>
+    /// Constructor with default window title
+    /// </summary>
+    /// <param name="filename"></param>
     public Report(string filename)
     {
         Filename = filename;
     }
 
-    /// <inheritdoc/>
+    /// <summary>
+    /// Constructor with custom window title
+    /// </summary>
+    /// <param name="filename"></param>
+    /// <param name="title"></param>
     public Report(string filename, string title)
     {
         Filename = filename;
@@ -29,7 +36,7 @@ public sealed class Report
     /// <param name="filename"></param>
     /// <param name="where"></param>
     /// <param name="parameters"></param>
-    public Report(string filename, string where, List<KeyValuePair<string, object>> parameters)
+    public Report(string filename, string where, IEnumerable<KeyValuePair<string, object>> parameters)
     {
         Filename = filename;
         WhereStatement = where;
@@ -39,7 +46,12 @@ public sealed class Report
         }
     }
 
-    /// <inheritdoc/>
+    /// <summary>
+    /// Constructor for serialization
+    /// </summary>
+    /// <param name="filename"></param>
+    /// <param name="title"></param>
+    /// <param name="exportFilename"></param>
     [JsonConstructor]
     public Report(string filename, string title, string exportFilename)
     {
@@ -70,10 +82,15 @@ public sealed class Report
     /// </summary>
     public PaperOrientations PaperOrientation { get; set; }
 
-    /// <inheritdoc/>
+    /// <summary>
+    /// Holds the database connection properties.
+    /// </summary>
     public CrystalReportsConnection? Connection { get; set; }
 
-    /// <inheritdoc/>
+    /// <summary>
+    /// All report parameters, that the report needs.
+    /// One can provide more parameters, than the report needs. The unused ones will be discarded.
+    /// </summary>
     public Dictionary<string, object> Parameters { get; set; } = [];
 
     /// <summary>
@@ -81,6 +98,8 @@ public sealed class Report
     /// </summary>
     public string WhereStatement { get; set; } = string.Empty;
 
-    /// <inheritdoc/>
+    /// <summary>
+    /// Used for the sample projects.
+    /// </summary>
     public List<DataSet> DataSets { get; set; } = [];
 }

--- a/src/LijsDev.CrystalReportsRunner.Core/Report.cs
+++ b/src/LijsDev.CrystalReportsRunner.Core/Report.cs
@@ -22,6 +22,23 @@ public sealed class Report
         Title = title;
     }
 
+    /// <summary>
+    /// Constructor that allows to specify the where-statement as well as the parameters at instantiation.
+    /// All parameters will be added to the internal dictionary.
+    /// </summary>
+    /// <param name="filename"></param>
+    /// <param name="where"></param>
+    /// <param name="parameters"></param>
+    public Report(string filename, string where, List<KeyValuePair<string, object>> parameters)
+    {
+        Filename = filename;
+        WhereStatement = where;
+        foreach (var parameter in parameters)
+        {
+            Parameters.Add(parameter.Key, parameter.Value);
+        }
+    }
+
     /// <inheritdoc/>
     [JsonConstructor]
     public Report(string filename, string title, string exportFilename)

--- a/src/LijsDev.CrystalReportsRunner/LijsDev.CrystalReportsRunner.13.0.20.x64/LijsDev.CrystalReportsRunner.13.0.20.x64.csproj
+++ b/src/LijsDev.CrystalReportsRunner/LijsDev.CrystalReportsRunner.13.0.20.x64/LijsDev.CrystalReportsRunner.13.0.20.x64.csproj
@@ -35,6 +35,7 @@
     <Compile Include="..\shared\Program.cs" Link="Program.cs" />
     <Compile Include="..\shared\ReportExporter.cs" Link="ReportExporter.cs" />
     <Compile Include="..\shared\ReportUtils.cs" Link="ReportUtils.cs" />
+    <Compile Include="..\shared\CustomReportDocument.cs" Link="CustomReportDocument.cs" />
     <Compile Include="..\shared\ReportViewer.cs" Link="ReportViewer.cs" />
     <Compile Include="..\shared\RuntimePolicyHelper.cs" Link="RuntimePolicyHelper.cs" />
     <Compile Include="..\shared\ViewerForm.cs" Link="ViewerForm.cs" />

--- a/src/LijsDev.CrystalReportsRunner/LijsDev.CrystalReportsRunner.13.0.20.x86/LijsDev.CrystalReportsRunner.13.0.20.x86.csproj
+++ b/src/LijsDev.CrystalReportsRunner/LijsDev.CrystalReportsRunner.13.0.20.x86/LijsDev.CrystalReportsRunner.13.0.20.x86.csproj
@@ -35,6 +35,7 @@
     <Compile Include="..\shared\Program.cs" Link="Program.cs" />
     <Compile Include="..\shared\ReportExporter.cs" Link="ReportExporter.cs" />
     <Compile Include="..\shared\ReportUtils.cs" Link="ReportUtils.cs" />
+    <Compile Include="..\shared\CustomReportDocument.cs" Link="CustomReportDocument.cs" />
     <Compile Include="..\shared\ReportViewer.cs" Link="ReportViewer.cs" />
     <Compile Include="..\shared\RuntimePolicyHelper.cs" Link="RuntimePolicyHelper.cs" />
     <Compile Include="..\shared\ViewerForm.cs" Link="ViewerForm.cs" />

--- a/src/LijsDev.CrystalReportsRunner/LijsDev.CrystalReportsRunner.13.0.31.x64/LijsDev.CrystalReportsRunner.13.0.31.x64.csproj
+++ b/src/LijsDev.CrystalReportsRunner/LijsDev.CrystalReportsRunner.13.0.31.x64/LijsDev.CrystalReportsRunner.13.0.31.x64.csproj
@@ -35,6 +35,7 @@
     <Compile Include="..\shared\Program.cs" Link="Program.cs" />
     <Compile Include="..\shared\ReportExporter.cs" Link="ReportExporter.cs" />
     <Compile Include="..\shared\ReportUtils.cs" Link="ReportUtils.cs" />
+    <Compile Include="..\shared\CustomReportDocument.cs" Link="CustomReportDocument.cs" />
     <Compile Include="..\shared\ReportViewer.cs" Link="ReportViewer.cs" />
     <Compile Include="..\shared\RuntimePolicyHelper.cs" Link="RuntimePolicyHelper.cs" />
     <Compile Include="..\shared\ViewerForm.cs" Link="ViewerForm.cs" />

--- a/src/LijsDev.CrystalReportsRunner/LijsDev.CrystalReportsRunner.13.0.31.x86/LijsDev.CrystalReportsRunner.13.0.31.x86.csproj
+++ b/src/LijsDev.CrystalReportsRunner/LijsDev.CrystalReportsRunner.13.0.31.x86/LijsDev.CrystalReportsRunner.13.0.31.x86.csproj
@@ -35,6 +35,7 @@
     <Compile Include="..\shared\Program.cs" Link="Program.cs" />
     <Compile Include="..\shared\ReportExporter.cs" Link="ReportExporter.cs" />
     <Compile Include="..\shared\ReportUtils.cs" Link="ReportUtils.cs" />
+    <Compile Include="..\shared\CustomReportDocument.cs" Link="CustomReportDocument.cs" />
     <Compile Include="..\shared\ReportViewer.cs" Link="ReportViewer.cs" />
     <Compile Include="..\shared\RuntimePolicyHelper.cs" Link="RuntimePolicyHelper.cs" />
     <Compile Include="..\shared\ViewerForm.cs" Link="ViewerForm.cs" />

--- a/src/LijsDev.CrystalReportsRunner/LijsDev.CrystalReportsRunner.13.0.32.x64/LijsDev.CrystalReportsRunner.13.0.32.x64.csproj
+++ b/src/LijsDev.CrystalReportsRunner/LijsDev.CrystalReportsRunner.13.0.32.x64/LijsDev.CrystalReportsRunner.13.0.32.x64.csproj
@@ -35,6 +35,7 @@
     <Compile Include="..\shared\Program.cs" Link="Program.cs" />
     <Compile Include="..\shared\ReportExporter.cs" Link="ReportExporter.cs" />
     <Compile Include="..\shared\ReportUtils.cs" Link="ReportUtils.cs" />
+    <Compile Include="..\shared\CustomReportDocument.cs" Link="CustomReportDocument.cs" />
     <Compile Include="..\shared\ReportViewer.cs" Link="ReportViewer.cs" />
     <Compile Include="..\shared\RuntimePolicyHelper.cs" Link="RuntimePolicyHelper.cs" />
     <Compile Include="..\shared\ViewerForm.cs" Link="ViewerForm.cs" />

--- a/src/LijsDev.CrystalReportsRunner/LijsDev.CrystalReportsRunner.13.0.32.x86/LijsDev.CrystalReportsRunner.13.0.32.x86.csproj
+++ b/src/LijsDev.CrystalReportsRunner/LijsDev.CrystalReportsRunner.13.0.32.x86/LijsDev.CrystalReportsRunner.13.0.32.x86.csproj
@@ -35,6 +35,7 @@
     <Compile Include="..\shared\Program.cs" Link="Program.cs" />
     <Compile Include="..\shared\ReportExporter.cs" Link="ReportExporter.cs" />
     <Compile Include="..\shared\ReportUtils.cs" Link="ReportUtils.cs" />
+    <Compile Include="..\shared\CustomReportDocument.cs" Link="CustomReportDocument.cs" />
     <Compile Include="..\shared\ReportViewer.cs" Link="ReportViewer.cs" />
     <Compile Include="..\shared\RuntimePolicyHelper.cs" Link="RuntimePolicyHelper.cs" />
     <Compile Include="..\shared\ViewerForm.cs" Link="ViewerForm.cs" />

--- a/src/LijsDev.CrystalReportsRunner/LijsDev.CrystalReportsRunner.13.0.33.x64/LijsDev.CrystalReportsRunner.13.0.33.x64.csproj
+++ b/src/LijsDev.CrystalReportsRunner/LijsDev.CrystalReportsRunner.13.0.33.x64/LijsDev.CrystalReportsRunner.13.0.33.x64.csproj
@@ -35,6 +35,7 @@
     <Compile Include="..\shared\Program.cs" Link="Program.cs" />
     <Compile Include="..\shared\ReportExporter.cs" Link="ReportExporter.cs" />
     <Compile Include="..\shared\ReportUtils.cs" Link="ReportUtils.cs" />
+    <Compile Include="..\shared\CustomReportDocument.cs" Link="CustomReportDocument.cs" />
     <Compile Include="..\shared\ReportViewer.cs" Link="ReportViewer.cs" />
     <Compile Include="..\shared\RuntimePolicyHelper.cs" Link="RuntimePolicyHelper.cs" />
     <Compile Include="..\shared\ViewerForm.cs" Link="ViewerForm.cs" />

--- a/src/LijsDev.CrystalReportsRunner/LijsDev.CrystalReportsRunner.13.0.33.x86/LijsDev.CrystalReportsRunner.13.0.33.x86.csproj
+++ b/src/LijsDev.CrystalReportsRunner/LijsDev.CrystalReportsRunner.13.0.33.x86/LijsDev.CrystalReportsRunner.13.0.33.x86.csproj
@@ -35,6 +35,7 @@
     <Compile Include="..\shared\Program.cs" Link="Program.cs" />
     <Compile Include="..\shared\ReportExporter.cs" Link="ReportExporter.cs" />
     <Compile Include="..\shared\ReportUtils.cs" Link="ReportUtils.cs" />
+    <Compile Include="..\shared\CustomReportDocument.cs" Link="CustomReportDocument.cs" />
     <Compile Include="..\shared\ReportViewer.cs" Link="ReportViewer.cs" />
     <Compile Include="..\shared\RuntimePolicyHelper.cs" Link="RuntimePolicyHelper.cs" />
     <Compile Include="..\shared\ViewerForm.cs" Link="ViewerForm.cs" />

--- a/src/LijsDev.CrystalReportsRunner/LijsDev.CrystalReportsRunner.13.0.34.x64/LijsDev.CrystalReportsRunner.13.0.34.x64.csproj
+++ b/src/LijsDev.CrystalReportsRunner/LijsDev.CrystalReportsRunner.13.0.34.x64/LijsDev.CrystalReportsRunner.13.0.34.x64.csproj
@@ -35,6 +35,7 @@
     <Compile Include="..\shared\Program.cs" Link="Program.cs" />
     <Compile Include="..\shared\ReportExporter.cs" Link="ReportExporter.cs" />
     <Compile Include="..\shared\ReportUtils.cs" Link="ReportUtils.cs" />
+    <Compile Include="..\shared\CustomReportDocument.cs" Link="CustomReportDocument.cs" />
     <Compile Include="..\shared\ReportViewer.cs" Link="ReportViewer.cs" />
     <Compile Include="..\shared\RuntimePolicyHelper.cs" Link="RuntimePolicyHelper.cs" />
     <Compile Include="..\shared\ViewerForm.cs" Link="ViewerForm.cs" />

--- a/src/LijsDev.CrystalReportsRunner/LijsDev.CrystalReportsRunner.13.0.34.x86/LijsDev.CrystalReportsRunner.13.0.34.x86.csproj
+++ b/src/LijsDev.CrystalReportsRunner/LijsDev.CrystalReportsRunner.13.0.34.x86/LijsDev.CrystalReportsRunner.13.0.34.x86.csproj
@@ -35,6 +35,7 @@
     <Compile Include="..\shared\Program.cs" Link="Program.cs" />
     <Compile Include="..\shared\ReportExporter.cs" Link="ReportExporter.cs" />
     <Compile Include="..\shared\ReportUtils.cs" Link="ReportUtils.cs" />
+    <Compile Include="..\shared\CustomReportDocument.cs" Link="CustomReportDocument.cs" />
     <Compile Include="..\shared\ReportViewer.cs" Link="ReportViewer.cs" />
     <Compile Include="..\shared\RuntimePolicyHelper.cs" Link="RuntimePolicyHelper.cs" />
     <Compile Include="..\shared\ViewerForm.cs" Link="ViewerForm.cs" />

--- a/src/LijsDev.CrystalReportsRunner/LijsDev.CrystalReportsRunner.13.0.35.x64/LijsDev.CrystalReportsRunner.13.0.35.x64.csproj
+++ b/src/LijsDev.CrystalReportsRunner/LijsDev.CrystalReportsRunner.13.0.35.x64/LijsDev.CrystalReportsRunner.13.0.35.x64.csproj
@@ -35,6 +35,7 @@
     <Compile Include="..\shared\Program.cs" Link="Program.cs" />
     <Compile Include="..\shared\ReportExporter.cs" Link="ReportExporter.cs" />
     <Compile Include="..\shared\ReportUtils.cs" Link="ReportUtils.cs" />
+    <Compile Include="..\shared\CustomReportDocument.cs" Link="CustomReportDocument.cs" />
     <Compile Include="..\shared\ReportViewer.cs" Link="ReportViewer.cs" />
     <Compile Include="..\shared\RuntimePolicyHelper.cs" Link="RuntimePolicyHelper.cs" />
     <Compile Include="..\shared\ViewerForm.cs" Link="ViewerForm.cs" />

--- a/src/LijsDev.CrystalReportsRunner/LijsDev.CrystalReportsRunner.13.0.35.x86/LijsDev.CrystalReportsRunner.13.0.35.x86.csproj
+++ b/src/LijsDev.CrystalReportsRunner/LijsDev.CrystalReportsRunner.13.0.35.x86/LijsDev.CrystalReportsRunner.13.0.35.x86.csproj
@@ -35,6 +35,7 @@
     <Compile Include="..\shared\Program.cs" Link="Program.cs" />
     <Compile Include="..\shared\ReportExporter.cs" Link="ReportExporter.cs" />
     <Compile Include="..\shared\ReportUtils.cs" Link="ReportUtils.cs" />
+    <Compile Include="..\shared\CustomReportDocument.cs" Link="CustomReportDocument.cs" />
     <Compile Include="..\shared\ReportViewer.cs" Link="ReportViewer.cs" />
     <Compile Include="..\shared\RuntimePolicyHelper.cs" Link="RuntimePolicyHelper.cs" />
     <Compile Include="..\shared\ViewerForm.cs" Link="ViewerForm.cs" />

--- a/src/LijsDev.CrystalReportsRunner/LijsDev.CrystalReportsRunner.13.0.36.x64/LijsDev.CrystalReportsRunner.13.0.36.x64.csproj
+++ b/src/LijsDev.CrystalReportsRunner/LijsDev.CrystalReportsRunner.13.0.36.x64/LijsDev.CrystalReportsRunner.13.0.36.x64.csproj
@@ -39,6 +39,7 @@
     <Compile Include="..\shared\Program.cs" Link="Program.cs" />
     <Compile Include="..\shared\ReportExporter.cs" Link="ReportExporter.cs" />
     <Compile Include="..\shared\ReportUtils.cs" Link="ReportUtils.cs" />
+    <Compile Include="..\shared\CustomReportDocument.cs" Link="CustomReportDocument.cs" />
     <Compile Include="..\shared\ReportViewer.cs" Link="ReportViewer.cs" />
     <Compile Include="..\shared\RuntimePolicyHelper.cs" Link="RuntimePolicyHelper.cs" />
     <Compile Include="..\shared\ViewerForm.cs" Link="ViewerForm.cs" />

--- a/src/LijsDev.CrystalReportsRunner/shared/CustomReportDocument.cs
+++ b/src/LijsDev.CrystalReportsRunner/shared/CustomReportDocument.cs
@@ -1,0 +1,205 @@
+namespace LijsDev.CrystalReportsRunner.Shell;
+
+using System.Drawing.Printing;
+using CrystalDecisions.CrystalReports.Engine;
+using CrystalDecisions.Shared;
+using PaperSource = CrystalDecisions.Shared.PaperSource;
+
+/// <summary>
+/// Report-Document mit Erweiterungen
+/// </summary>
+public class CustomReportDocument : ReportDocument
+{
+    private string _origRecordSelectionFormula = string.Empty;
+
+    /// <summary>
+    /// Lädt den angegebenen Report
+    /// </summary>
+    /// <param name="filename">Dateiname</param>
+    public override void Load(string filename)
+    {
+        base.Load(filename);
+        _origRecordSelectionFormula = RecordSelectionFormula;
+    }
+
+    /// <summary>
+    /// Speichert den angegebenen Report
+    /// </summary>
+    /// <param name="filename">Dateiname</param>
+    public override void SaveAs(string filename)
+    {
+        if (_origRecordSelectionFormula != RecordSelectionFormula)
+        {
+            RecordSelectionFormula = _origRecordSelectionFormula;
+        }
+
+        //Falls Datei nicht schreibgeschützt ist, speichern
+        filename = filename.Replace("rassdk://", "");
+        if ((File.GetAttributes(filename) & FileAttributes.ReadOnly) !=
+            FileAttributes.ReadOnly)
+        {
+            base.SaveAs(filename);
+        }
+    }
+
+    /// <summary>
+    /// Report-Titel
+    /// </summary>
+    public string ReportTitle
+    {
+        get => SummaryInfo.ReportTitle;
+        set => SummaryInfo.ReportTitle = value;
+    }
+
+    /// <summary>
+    /// Setzt die Parameterwerte
+    /// </summary>
+    /// <param name="name">Name</param>
+    /// <param name="value">Wert</param>
+    public void SetParameterValueIfExists(string name, object value)
+    {
+        var par = ParameterFields.Find(name, "");
+        if (par != null)
+        {
+            SetParameterValue(name, value);
+        }
+    }
+
+    /// <summary>
+    /// Druckt den Report
+    /// </summary>
+    public void Print()
+    {
+        var ps = new PrinterSettings();
+        var pd = new PrintDocument();
+        LoadPrinterData(ps);
+        //Standarddrucker nehmen, falls der aktuelle Drucker ungültig ist
+        if (!ps.IsValid)
+        {
+            ps.PrinterName = pd.PrinterSettings.PrinterName;
+        }
+
+        var req = new ReportPageRequestContext();
+        var topage = FormatEngine.GetLastPageNumber(req);
+        ps.MaximumPage = 99999;
+        ps.MinimumPage = 1;
+        ps.ToPage = topage;
+        ps.FromPage = 1;
+        PrintToPrinter(ps, new PageSettings(ps), false);
+    }
+
+    /// <summary>
+    /// Lädt die Druckereinstellungen
+    /// </summary>
+    /// <param name="ps">Druckereinstellungen</param>
+    public void LoadPrinterData(PrinterSettings ps)
+    {
+        ps.PrinterName = this.PrintOptions.PrinterName;
+        if (((this.SummaryInfo.ReportTitle == null) ? 0 : this.SummaryInfo.ReportTitle.Length) > 0)
+        {
+            ps.PrintFileName = this.SummaryInfo.ReportTitle;
+        }
+
+        switch (this.PrintOptions.PrinterDuplex)
+        {
+            case PrinterDuplex.Default:
+                ps.Duplex = Duplex.Default;
+                break;
+            case PrinterDuplex.Simplex:
+                ps.Duplex = Duplex.Simplex;
+                break;
+            case PrinterDuplex.Horizontal:
+                ps.Duplex = Duplex.Horizontal;
+                break;
+            case PrinterDuplex.Vertical:
+                ps.Duplex = Duplex.Vertical;
+                break;
+        }
+
+        //Papersource laden
+        var paperSource = PaperSourceKind.AutomaticFeed;
+        switch (this.PrintOptions.PaperSource)
+        {
+            case PaperSource.Cassette:
+                paperSource = PaperSourceKind.Cassette;
+                break;
+            case PaperSource.Manual:
+                paperSource = PaperSourceKind.Manual;
+                break;
+            case PaperSource.Upper:
+                paperSource = PaperSourceKind.Upper;
+                break;
+            case PaperSource.Lower:
+                paperSource = PaperSourceKind.Lower;
+                break;
+            case PaperSource.Middle:
+                paperSource = PaperSourceKind.Middle;
+                break;
+        }
+
+        foreach (System.Drawing.Printing.PaperSource pas in ps.PaperSources)
+        {
+            if (pas.Kind == paperSource)
+            {
+                ps.DefaultPageSettings.PaperSource = pas;
+                break;
+            }
+        }
+
+        ps.DefaultPageSettings.Landscape = this.PrintOptions.PaperOrientation == PaperOrientation.Landscape;
+        //ps.DefaultPageSettings.PaperSize = (PaperSize)this.PrintOptions.PaperSize;
+    }
+
+    /// <summary>
+    /// Speichert die Druckereinstellungen
+    /// </summary>
+    /// <param name="ps"></param>
+    public void SavePrinterData(PrinterSettings ps)
+    {
+        this.PrintOptions.PrinterName = ps.PrinterName;
+        switch (ps.Duplex)
+        {
+            case Duplex.Default:
+                this.PrintOptions.PrinterDuplex = PrinterDuplex.Default;
+                break;
+            case Duplex.Simplex:
+                this.PrintOptions.PrinterDuplex = PrinterDuplex.Simplex;
+                break;
+            case Duplex.Horizontal:
+                this.PrintOptions.PrinterDuplex = PrinterDuplex.Horizontal;
+                break;
+            case Duplex.Vertical:
+                this.PrintOptions.PrinterDuplex = PrinterDuplex.Vertical;
+                break;
+        }
+
+        //Papier Quelle speichern
+        switch (ps.DefaultPageSettings.PaperSource.Kind)
+        {
+            case PaperSourceKind.AutomaticFeed:
+                this.PrintOptions.PaperSource = PaperSource.Auto;
+                break;
+            case PaperSourceKind.Cassette:
+                this.PrintOptions.PaperSource = PaperSource.Cassette;
+                break;
+            case PaperSourceKind.Manual:
+                this.PrintOptions.PaperSource = PaperSource.Manual;
+                break;
+            case PaperSourceKind.Upper:
+                this.PrintOptions.PaperSource = PaperSource.Upper;
+                break;
+            case PaperSourceKind.Lower:
+                this.PrintOptions.PaperSource = PaperSource.Lower;
+                break;
+            case PaperSourceKind.Middle:
+                this.PrintOptions.PaperSource = PaperSource.Middle;
+                break;
+            default:
+                this.PrintOptions.PaperSource = PaperSource.Auto;
+                break;
+        }
+
+        this.PrintOptions.PaperOrientation = ps.DefaultPageSettings.Landscape ? PaperOrientation.Landscape : PaperOrientation.Portrait;
+        //this.PrintOptions.PaperSize = (CrystalDecisions.Shared.PaperSize)ps.DefaultPageSettings.PaperSize;
+    }
+}

--- a/src/LijsDev.CrystalReportsRunner/shared/ReportUtils.cs
+++ b/src/LijsDev.CrystalReportsRunner/shared/ReportUtils.cs
@@ -1,174 +1,134 @@
 namespace LijsDev.CrystalReportsRunner;
 
 using CrystalDecisions.CrystalReports.Engine;
-using CrystalDecisions.Shared;
-
-using System.Collections.Generic;
-using System.Data;
-
-using LijsDev.CrystalReportsRunner.Core;
+using Shell;
 
 internal static class ReportUtils
 {
-    private static readonly NLog.Logger Logger = NLog.LogManager.GetCurrentClassLogger();
-
-    public static ReportDocument CreateReportDocument(Report report)
+    public static CustomReportDocument CreateReportDocument(Core.Report report)
     {
-        Logger.Trace("LijsDev::CrystalReportsRunner::ReportUtils::CreateReportDocument::Start");
-        Logger.Trace($"LijsDev::CrystalReportsRunner::ReportUtils::CreateReportDocument::Filename={report.Filename}");
-
-        var document = new ReportDocument();
-        document.Load(report.Filename);
-
-        Logger.Trace("LijsDev::CrystalReportsRunner::ReportUtils::CreateReportDocument::ReportDocument::Loaded");
-
-        // Cache logon properties
-        var logonProperties = report.Connection is not null ? CreateLogonPropertiesFromConnection(report.Connection) : null;
-
-        if (report.Connection is not null)
+        var doc = new CustomReportDocument();
+        try
         {
-            Logger.Trace("LijsDev::CrystalReportsRunner::ReportUtils::CreateReportDocument::Connection::Configuring");
-            Logger.Trace($"LijsDev::CrystalReportsRunner::ReportUtils::CreateReportDocument::Connection::Server={report.Connection.Server}");
-            Logger.Trace($"LijsDev::CrystalReportsRunner::ReportUtils::CreateReportDocument::Connection::Server={report.Connection.Database}");
+            var dbChanged = false;
 
-            for (var i = 0; i < document.DataSourceConnections.Count; i++)
+            doc.Load(report.Filename);
+
+            //Check Report Datenbankverbindung geändert?
+            if (report.Connection is not null)
             {
-                ConfigureDataSourceConnection(document.DataSourceConnections[i], report.Connection, logonProperties);
-
-                // NB: We need to set data source configuration twice, otherwise it does not work. Very strange Crystal Reports behaviour. Could be improved with the right code/order to set connections.
-                ConfigureDataSourceConnection(document.DataSourceConnections[i], report.Connection, logonProperties);
-            }
-
-            foreach (ReportDocument subReport in document.Subreports)
-            {
-                for (var i = 0; i < subReport.DataSourceConnections.Count; i++)
+                if (doc.DataSourceConnections[0].ServerName != report.Connection.Server
+                    || doc.DataSourceConnections[0].DatabaseName != report.Connection.Database
+                    || doc.DataSourceConnections[0].IntegratedSecurity != report.Connection.UseIntegratedSecurity)
                 {
-                    ConfigureDataSourceConnection(subReport.DataSourceConnections[i], report.Connection, logonProperties);
+                    doc.DataSourceConnections.Clear();
+                    doc.DataSourceConnections[0]
+                        .SetConnection(report.Connection.Server, report.Connection.Database, report.Connection.UseIntegratedSecurity);
+                    dbChanged = true;
+                }
 
-                    // NB: We need to set data source configuration twice, otherwise it does not work. Very strange Crystal Reports behaviour. Could be improved with the right code/order to set connections.
-                    ConfigureDataSourceConnection(subReport.DataSourceConnections[i], report.Connection, logonProperties);
+                //Hat die Datenbankverbindung in den Subreports geändert?
+                foreach (ReportDocument subReport in doc.Subreports)
+                {
+                    subReport.DataSourceConnections.Clear();
+                    if (subReport.DataSourceConnections[0].ServerName != report.Connection.Server
+                        || subReport.DataSourceConnections[0].DatabaseName != report.Connection.Database
+                        || subReport.DataSourceConnections[0].IntegratedSecurity != report.Connection.UseIntegratedSecurity)
+                    {
+                        subReport.DataSourceConnections[0]
+                            .SetConnection(report.Connection.Server, report.Connection.Database, report.Connection.UseIntegratedSecurity);
+                        dbChanged = true;
+                    }
                 }
             }
-        }
 
-        // Main Report
-        foreach (Table crTable in document.Database.Tables)
-        {
-            ConfigureTableConnection(crTable, report.Connection, logonProperties);
-            ConfigureTableDataSource(crTable, report.DataSets);
-        }
-        // Sub Reports
-        foreach (ReportDocument crSubReport in document.Subreports)
-        {
-            foreach (Table crTable in crSubReport.Database.Tables)
+            //Benutzername und Passwort, falls SQL-Authentifizierung
+            if (!doc.DataSourceConnections[0].IntegratedSecurity)
             {
-                ConfigureTableConnection(crTable, report.Connection, logonProperties);
-                ConfigureTableDataSource(crTable, report.DataSets);
+                doc.DataSourceConnections[0].SetLogon(report.Connection?.Username, report.Connection?.Password);
             }
+
+            //Changed?
+            if (dbChanged)
+            {
+                if (report.Connection?.UseIntegratedSecurity != true)
+                {
+                    try
+                    {
+                        doc.VerifyDatabase();
+                    }
+                    catch
+                    {
+                        // TODO: Figure out why this catch is empty
+                    }
+
+                    //SetReportParameters(doc, whereStatement, parameters);
+                }
+
+                doc.SaveAs(report.Filename, false);
+            }
+
+            //Parameter setzen
+            SetReportParameters(doc, report.WhereStatement, report.Parameters);
+        }
+        catch (Exception ex)
+        {
+            var logon = "";
+            if (doc != null)
+            {
+                if (doc.IsLoaded)
+                {
+                    logon = doc.DataSourceConnections[0].ServerName + "\r\n" +
+                            doc.DataSourceConnections[0].DatabaseName + "\r\n" +
+                            doc.DataSourceConnections[0].Type;
+                }
+            }
+
+            var mess = ex.Message;
+            if (ex.InnerException != null)
+            {
+                mess = ex.InnerException.Message;
+            }
+
+            throw new Exception("Failed to open report:" + "'" + report.Filename + "'\r\n" + logon + "\r\n Exception:" + mess);
         }
 
-        // Set parameters
-        foreach (ParameterField parameter in document.ParameterFields)
+        return doc;
+    }
+
+    private static void SetReportParameters(CustomReportDocument reportDocument, string whereStatement, Dictionary<string, object> parameters)
+    {
+        var reportParameters = parameters;
+
+        //StandardParameter vordefinieren
+        foreach (var parameter in reportParameters)
         {
-            if (report.Parameters.TryGetValue(parameter.ParameterFieldName, out var value))
+            reportDocument.SetParameterValueIfExists(parameter.Key, parameter.Value);
+        }
+
+        //WHERE Setzen
+        if (whereStatement.Length > 0)
+        {
+            if (whereStatement.Contains("{"))
             {
-                Logger.Trace($"LijsDev::CrystalReportsRunner::ReportUtils::CreateReportDocument::SetParameter={parameter.ParameterFieldName} | Value={value}");
-                parameter.CurrentValues.Clear();
-                if (value.GetType() != typeof(string) && value is System.Collections.IEnumerable valueEnumerable)
+                if (reportDocument.RecordSelectionFormula.Length > 0)
                 {
-                    foreach (var valueItem in valueEnumerable)
-                    {
-                        parameter.CurrentValues.AddValue(valueItem);
-                    }
+                    reportDocument.RecordSelectionFormula = "(" + reportDocument.RecordSelectionFormula +
+                                                            ")  AND  (" + whereStatement + ")";
                 }
                 else
                 {
-                    parameter.CurrentValues.AddValue(value);
+                    reportDocument.RecordSelectionFormula = whereStatement;
                 }
             }
-        }
-
-        // NB: SummaryInfo.ReportTitle is used as initial value in save dialog when exporting a report.
-        document.SummaryInfo.ReportTitle = report.ExportFilename ?? report.Title;
-
-        Logger.Trace("LijsDev::CrystalReportsRunner::ReportUtils::CreateReportDocument::End");
-        return document;
-    }
-
-    private static NameValuePairs2 CreateLogonPropertiesFromConnection(CrystalReportsConnection crystalReportsConnection)
-    {
-        var logonProperties = new NameValuePairs2()
-        {
-            new NameValuePair2("Data Source", crystalReportsConnection.Server),
-            new NameValuePair2("Initial Catalog", crystalReportsConnection.Database),
-            new NameValuePair2("Integrated Security", crystalReportsConnection.UseIntegratedSecurity),
-        };
-        if (crystalReportsConnection.LogonProperties is not null)
-        {
-            foreach (var property in crystalReportsConnection.LogonProperties)
+            else
             {
-                logonProperties.Add(new NameValuePair2(property.Key, property.Value));
-            }
-        }
-
-        return logonProperties;
-    }
-
-    private static void ConfigureDataSourceConnection(IConnectionInfo connection, CrystalReportsConnection? crystalReportsConnection, NameValuePairs2? logonProperties)
-    {
-        if (crystalReportsConnection is null) return;
-
-        // Apply logon properties
-        if (logonProperties is not null)
-        {
-            connection.SetLogonProperties(logonProperties);
-        }
-
-        // Apply connection
-        connection.IntegratedSecurity = crystalReportsConnection.UseIntegratedSecurity;
-        if (crystalReportsConnection.UseIntegratedSecurity)
-        {
-            connection.SetConnection(
-                crystalReportsConnection.Server, crystalReportsConnection.Database, useIntegratedSecurity: true);
-        }
-        else
-        {
-            connection.SetLogon(crystalReportsConnection.Username, crystalReportsConnection.Password);
-
-            connection.SetConnection(
-                crystalReportsConnection.Server,
-                crystalReportsConnection.Database,
-                crystalReportsConnection.Username,
-                crystalReportsConnection.Password);
-        }
-    }
-
-    private static void ConfigureTableConnection(Table crTable, CrystalReportsConnection? crystalReportsConnection, NameValuePairs2? logonProperties)
-    {
-        if (crystalReportsConnection is null) return;
-
-        crTable.LogOnInfo.ConnectionInfo.ServerName = crystalReportsConnection.Server;
-        crTable.LogOnInfo.ConnectionInfo.DatabaseName = crystalReportsConnection.Database;
-        crTable.LogOnInfo.ConnectionInfo.UserID = crystalReportsConnection.Username;
-        crTable.LogOnInfo.ConnectionInfo.Password = crystalReportsConnection.Password;
-        crTable.LogOnInfo.ConnectionInfo.IntegratedSecurity = crystalReportsConnection.UseIntegratedSecurity;
-
-        if (logonProperties is not null)
-        {
-            crTable.LogOnInfo.ConnectionInfo.LogonProperties = logonProperties;
-        }
-
-        crTable.ApplyLogOnInfo(crTable.LogOnInfo);
-    }
-
-    private static void ConfigureTableDataSource(Table crTable, List<DataSet> datasets)
-    {
-        foreach (var item in datasets)
-        {
-            if (item.Tables.Contains(crTable.Name))
-            {
-                crTable.SetDataSource(item.Tables[crTable.Name]);
-                return;
+                var splitParameter = whereStatement.Split('=');
+                var whereParameter = reportDocument.ParameterFields.Find(splitParameter[0], "");
+                if (whereParameter != null)
+                {
+                    reportDocument.SetParameterValue(splitParameter[0], splitParameter[1]);
+                }
             }
         }
     }

--- a/src/LijsDev.CrystalReportsRunner/shared/ReportUtils.cs
+++ b/src/LijsDev.CrystalReportsRunner/shared/ReportUtils.cs
@@ -1,12 +1,18 @@
 namespace LijsDev.CrystalReportsRunner;
 
+using Core;
 using CrystalDecisions.CrystalReports.Engine;
+using NLog;
 using Shell;
 
 internal static class ReportUtils
 {
-    public static CustomReportDocument CreateReportDocument(Core.Report report)
+    private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
+
+    public static CustomReportDocument CreateReportDocument(Report report)
     {
+        Logger.Trace($"LijsDev::CrystalReportsRunner::ReportUtils::CreateReportDocument::Filename={report.Filename}");
+
         var doc = new CustomReportDocument();
         try
         {
@@ -57,12 +63,10 @@ internal static class ReportUtils
                     {
                         doc.VerifyDatabase();
                     }
-                    catch
+                    catch (Exception ex)
                     {
-                        // TODO: Figure out why this catch is empty
+                        Logger.Error(ex, "Could not verify the database connection.");
                     }
-
-                    //SetReportParameters(doc, whereStatement, parameters);
                 }
 
                 doc.SaveAs(report.Filename, false);


### PR DESCRIPTION
The processing of the parameters should take place in the runner. The report object merely serves as a container in which all standard parameters and their corresponding values can be filled in on the SisValor side. Therefore the CustomReportDocument was moved into the Runner too.